### PR TITLE
Shm_pool_offset_ptr impl: use native-union type-punning instead of re…

### DIFF
--- a/src/ipc/shm/arena_lend/shm_pool_offset_ptr.hpp
+++ b/src/ipc/shm/arena_lend/shm_pool_offset_ptr.hpp
@@ -102,7 +102,8 @@ public:
   Shm_pool_offset_ptr(const Shm_pool_offset_ptr& other) = default;
 
 /* gcc is pretty paranoid about the type-punning when initializing m_data below, but we know what we are doing.
- * The code appears solid, so let's bypass it temporarily. */
+ * The code appears solid, so let's bypass it temporarily. @todo Perhaps we can finagle-in a `union` to avoid
+ * the warning? */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 


### PR DESCRIPTION
…interpret_cast<> type-punning.  This was a longer-term-intended @todo, but some recent experiences brought this work forward.  Using union-ing between the uin64_t, the offset-ptr bit-field, and the raw-ptr bit-field turned out superior for a number of reasons.  (1) Certain aliasing-related warnings (which had to be pragma-ed away before) went away.  (2) In terms of readability and concision this way is slightly better.  (3) Most importantly: `volatile` is no longer necessary this way, as the gcc-9 (at least optimizer) no longer gets confused as to side-effects of certain code and no longer needs to be told to avoid optimization around certain memory areas.  It is now free to optimize how it wants, in this rather perf-critical code.