### PR TITLE
Disabling various DeathTests known to fail when assert()s are disable…

### DIFF
--- a/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
@@ -158,7 +158,11 @@ private:
 
 /// Death tests - suffixed with DeathTest per Googletest conventions, aliased to fixture.
 using Jemalloc_pages_DeathTest = Jemalloc_pages_test;
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST_F(Jemalloc_pages_DeathTest, DISABLED_Interface)
+#else
 TEST_F(Jemalloc_pages_DeathTest, Interface)
+#endif
 {
   bool commit;
 

--- a/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
@@ -808,7 +808,11 @@ private:
 }; // class Default_jemalloc_memory_manager
 
 /// Class interface death tests.
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST(Memory_manager_DeathTest, DISABLED_Interface)
+#else
 TEST(Memory_manager_DeathTest, Interface)
+#endif
 {
   Test_logger test_logger;
 
@@ -913,8 +917,13 @@ TEST(Jemalloc_memory_manager_test, Interface)
 /**
  * Tests to ensure default allocators/deallocators are not overridden.
  * NOTE: This only passes if jemalloc is not the default allocator.
+ *
+ * ygoldfel adds: As of this writing (11/2023) this test appears to ~always fail, at least if run as part of
+ * the overall suite.  I discussed briefly with echan (test author); he didn't have time to get into it yet,
+ * but generally I believe it might be a matter of ordering of this test versus others in the suite.
+ * For now disabling it (DISABLED_) to have a look later.
  */
-TEST(Jemalloc_memory_manager_test, No_default_override)
+TEST(Jemalloc_memory_manager_test, DISABLED_No_default_override)
 {
   // Allocate a large enough size that an allocation or split would likely be performed if jemalloc was used
   const size_t ALLOC_SIZE = Jemalloc_pages::get_page_size() * 1024 * 1024;

--- a/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
@@ -654,7 +654,11 @@ private:
 
 /// Death tests - suffixed with DeathTest per Googletest conventions, aliased to fixture.
 using Jemalloc_shm_pool_collection_DeathTest = Jemalloc_shm_pool_collection_test;
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST_F(Jemalloc_shm_pool_collection_DeathTest, DISABLED_Interface)
+#else
 TEST_F(Jemalloc_shm_pool_collection_DeathTest, Interface)
+#endif
 {
   auto collection = create_collection();
 

--- a/src/ipc/shm/arena_lend/test/memory_manager_test.cpp
+++ b/src/ipc/shm/arena_lend/test/memory_manager_test.cpp
@@ -33,7 +33,11 @@ namespace ipc::shm::arena_lend::test
 {
 
 /// Class interface death tests.
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST(Memory_manager_DeathTest, DISABLED_Interface)
+#else
 TEST(Memory_manager_DeathTest, Interface)
+#endif
 {
   Test_logger test_logger;
   Memory_manager memory_manager(&test_logger);

--- a/src/ipc/shm/arena_lend/test/owner_shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/test/owner_shm_pool_collection_test.cpp
@@ -397,7 +397,11 @@ private:
 
 /// Death tests - suffixed with DeathTest per Googletest conventions, which allows aliasing.
 using Owner_shm_pool_collection_DeathTest = Owner_shm_pool_collection_test;
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST_F(Owner_shm_pool_collection_DeathTest, DISABLED_Interface_death)
+#else
 TEST_F(Owner_shm_pool_collection_DeathTest, Interface_death)
+#endif
 {
   auto& collection = get_collection();
 

--- a/src/ipc/shm/arena_lend/test/shm_pool_test.cpp
+++ b/src/ipc/shm/arena_lend/test/shm_pool_test.cpp
@@ -50,7 +50,11 @@ static constexpr int S_FD = 12;
 } // Anonymous namespace
 
 /// Death tests (@todo - does it work with NDEBUG as with default CMake Release build-type? -ygoldfel)
+#ifdef NDEBUG // These "deaths" occur only if assert()s enabled; else these are guaranteed failures.
+TEST(Shm_pool_DeathTest, DISABLED_Interface)
+#else
 TEST(Shm_pool_DeathTest, Interface)
+#endif
 {
   EXPECT_DEATH(Shm_pool(0, S_NAME, S_ADDRESS, S_SIZE, S_FD), "id != 0");
   EXPECT_DEATH(Shm_pool(S_ID, "", S_ADDRESS, S_SIZE, S_FD), "!name.empty\\(\\)");


### PR DESCRIPTION
…d (NDEBUG) (only if indeed they are disabled).  Also disabling a certain specific test (as discussed with echan) needs special measures to be reliably useful.