### PR TITLE
(echan code) clang -fsanitize=address (ASAN) with unit_test or transp…

### DIFF
--- a/src/ipc/session/standalone/shm/arena_lend/borrower_collection.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/borrower_collection.cpp
@@ -78,10 +78,11 @@ shared_ptr<Shm_pool> Borrower_collection::deregister_shm_pool(pool_id_t shm_pool
     return nullptr;
   }
 
+  auto shm_pool = std::move(shm_pool_data.m_shm_pool); // Save before erasure of *&shm_pool_data from map.
   m_shm_pool_data_map.erase(iter);
   FLOW_LOG_TRACE("Deregistered SHM pool [" << shm_pool_id << "] in collection [" << get_id() << "]");
 
-  return shm_pool_data.m_shm_pool;
+  return shm_pool;
 }
 
 const shared_ptr<Shm_pool>& Borrower_collection::find_shm_pool(pool_id_t shm_pool_id) const


### PR DESCRIPTION
…ort_test (in SHM-jemalloc+exercise mode) reveals an actual problem in Borrower_collection.  It is a straightforward use of a reference after erasing underlying object from a container; just an oversight.  These tests proceed now even with ASAN (without ASAN it was working essentialy from luck, and in multi-threaded situations could break unprecitably).