### PR TITLE
TEST(Shm_session_data_test, Multithread_object_database) (by echan: t…

### DIFF
--- a/src/ipc/session/standalone/shm/arena_lend/test/shm_session_data_test.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/test/shm_session_data_test.cpp
@@ -1179,6 +1179,34 @@ TEST(Shm_session_data_test, Lender_object_database)
  * limit is hit, so the settings are capped to mitigate the probability of it occurring, while still having
  * sufficient entropy.
  */
+/* @todo This test sporadically fails (so far only seen in Debug config, sometimes, in open-source CI pipeline).
+ * I (ygoldfel) did not write the underlying code or the test, and it is too sophisticated for me to quickly
+ * understand/analyze, so I have created ticket and contacted the original author, echan. That said the test is
+ * important, so I am leaving it enabled even while it is slightly flaky; at least if something gets definitively
+ * broken in related functionality this test should make it abundantly clear despite the confounding flakiness
+ * (which of course we should eliminate as well).
+ *
+ * This has been seen a couple times:
+ *   [ RUN      ] Shm_session_data_test.Multithread_object_database
+ *   /home/runner/work/ipc/ipc/ipc_shm_arena_lend/src/ipc/session/standalone/shm/arena_lend/test/shm_session_data_test.cpp:1564: Failure
+ *   Value of: was_empty
+ *     Actual: false
+ *   Expected: true
+ *   /home/runner/work/ipc/ipc/ipc_shm_arena_lend/src/ipc/session/standalone/shm/arena_lend/test/shm_session_data_test.cpp:1556: Failure
+ *   Expected equality of these values:
+ *     object
+ *       Which is: (0x7f3b155bf001)
+ *     removed_object
+ *       Which is: (nullptr)
+ * This has been seen even less:
+ *   [ RUN      ] Shm_session_data_test.Multithread_object_database
+ *   /home/runner/work/ipc/ipc/ipc_shm_arena_lend/src/ipc/session/standalone/shm/arena_lend/test/shm_session_data_test.cpp:1717: Failure
+ *   Value of: session_data->deregister_borrower_shm_pool(collection_id, shm_pool_id)
+ *     Actual: false
+ *   Expected: true
+ *
+ * (Apologies; the line number may no longer be exact. The two groups of failures are in
+ * remove_lender_object_functor_helper() and remove_borrower_object_functor_helper() respectively.) */
 TEST(Shm_session_data_test, Multithread_object_database)
 {
   const size_t NUM_COLLECTIONS = 3;

--- a/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
@@ -321,8 +321,6 @@ TEST_F(Jemalloc_pages_DeathTest, Interface)
 TEST_F(Jemalloc_pages_test, Interface)
 {
   void* INVALID_ADDRESS = reinterpret_cast<void*>(S_PAGE_SIZE);
-  void* VALID_FIXED_ADDRESS = reinterpret_cast<void*>(S_PAGE_SIZE * 10000);
-  void* VALID_HUGE_PAGE_FIXED_ADDRESS = reinterpret_cast<void*>(S_HUGE_PAGE_SIZE * 100);
 
   bool commit;
 
@@ -343,21 +341,39 @@ TEST_F(Jemalloc_pages_test, Interface)
     map_test(nullptr, S_PAGE_SIZE, S_PAGE_SIZE, fd);
   }
   {
-    SCOPED_TRACE("Fixed address, page size with page size alignment");
-    map_test(VALID_FIXED_ADDRESS, S_PAGE_SIZE, S_PAGE_SIZE, fd);
-  } 
-  {
     SCOPED_TRACE("System chosen address, huge page size with page size alignment");
     map_test(nullptr, S_HUGE_PAGE_SIZE, S_PAGE_SIZE, fd);
-  } 
-  {
-    SCOPED_TRACE("Fixed huge page address, page size with huge page size alignment");
-    map_test(VALID_HUGE_PAGE_FIXED_ADDRESS, S_PAGE_SIZE, S_HUGE_PAGE_SIZE, fd);
   }
   {
     SCOPED_TRACE("System chosen address, huge page size with huge page size alignment");
     map_test(nullptr, S_HUGE_PAGE_SIZE, S_HUGE_PAGE_SIZE, fd);
-  } 
+  }
+
+  /* @todo This test sometimes fails. Empirically: so far I (ygoldfel) have personally never seen it myself,
+   * and as of this writing it only sometimes fails but only in a Debug configuration in the open-source CI
+   * pipeline (also not always there either). I very briefly looked into it; given this is a fixed-address mapping it
+   * should be a matter of a single OS ::mmap() either succeeding or failing, simple as that. So if it can sometimes
+   * fail given this odd fixed-address we pass-in, then this can fail. That said this is echan's feature and
+   * test, so I've filed a ticket and asked him about it, and in the meantime am disabling these. I can see
+   * that in the big picture this particular ability is tangential, in that we avoid needing fixed-address mapping
+   * in the general project. (Nevertheless of course we should unit-test this as robustly as we can, since it is
+   * part of the code, though unused generally).
+   *
+   * The 2nd huge-page check we have not seen fail as of this writing, but at its core it looks like a similar
+   * operation, so disabling it too, until we get clarity on the topic. */
+#if 0
+  void* VALID_FIXED_ADDRESS = reinterpret_cast<void*>(S_PAGE_SIZE * 10000);
+  void* VALID_HUGE_PAGE_FIXED_ADDRESS = reinterpret_cast<void*>(S_HUGE_PAGE_SIZE * 100);
+
+  {
+    SCOPED_TRACE("Fixed address, page size with page size alignment");
+    map_test(VALID_FIXED_ADDRESS, S_PAGE_SIZE, S_PAGE_SIZE, fd);
+  }
+  {
+    SCOPED_TRACE("Fixed huge page address, page size with huge page size alignment");
+    map_test(VALID_HUGE_PAGE_FIXED_ADDRESS, S_PAGE_SIZE, S_HUGE_PAGE_SIZE, fd);
+  }
+#endif
 
   // Check commit flag after mapping
   {


### PR DESCRIPTION
…est and features) is apparently slightly flaky and fails sporadically in CI pipeline.  Filing ticket about it; the added comment memorializes the known info so far. / Jemalloc_pages test (by echan, both functionality and test code) is apparently slightly flaky, sometimes failing in CI pipeline.  To my eyes this might well be a test at the mercy of OS mmap() innards, but I have contacted echan for more info/filing ticket.  In the meantime it seems about right to disable the particular part of the test that is in question: it is mmap()ing at a pre-specified raw address which is not used by the rest of the project really.