### PR TITLE
Tsan fun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore emacs auto-saves and recovery files; **/ to avoid picking it up as a comment.
+*~
+**/#*#
+
+# And this Mac stuff.
+.DS_Store

--- a/src/sanitize/ubsan/suppressions_clang.cfg
+++ b/src/sanitize/ubsan/suppressions_clang.cfg
@@ -1,0 +1,7 @@
+# src/jemalloc.c:3133:16: runtime error: left shift of 4095 by 20 places cannot be represented in type 'int'
+# Looks harmless... a macro is doing essentially `((1 << 12) - 1) << 20`, which is a negative int -- used as an & mask.
+# jemalloc should be more civilized IMO, but it is fine.
+# Lastly: docs say `shift` is a usable suppression type, but it is not; it is a grouping; one must use these
+# in the file.  Possibly just one of the two is enough, but let us not quibble.
+shift-base:je_mallocx
+shift-exponent:je_mallocx

--- a/src/sanitize/ubsan/suppressions_clang_15.cfg
+++ b/src/sanitize/ubsan/suppressions_clang_15.cfg
@@ -1,0 +1,1 @@
+suppressions_clang_17.cfg

--- a/src/sanitize/ubsan/suppressions_clang_16.cfg
+++ b/src/sanitize/ubsan/suppressions_clang_16.cfg
@@ -1,0 +1,1 @@
+suppressions_clang_17.cfg

--- a/src/sanitize/ubsan/suppressions_clang_17.cfg
+++ b/src/sanitize/ubsan/suppressions_clang_17.cfg
@@ -1,0 +1,8 @@
+# tcache.c:144:2: runtime error: variable length array bound evaluates to non-positive value 0
+# Gets invoked from some kind of cleanup hook.  Also look harmless in context, as the actual bound
+# being 0 controls various code touching the "array."  The var-length array is a gcc extension;
+# probably clang too then.
+# jemalloc should really not do this sort of thing though.
+vla-bound:je_tcache_bin_flush_small
+# (Very similar situation; skipping details.)
+vla-bound:je_tcache_bin_flush_large


### PR DESCRIPTION
More details in meta-project ipc commit(s) coming soon; this is a part of that. In particular here: 1, the ipc/ubsan_suppresions_*.cfg files all are moving here. There are ~2 distinct suppressions; all are within jemalloc and harmless; and only ipc_shm_arena_lend pulls in jemalloc; hence they belong here, not in meta-project. 2, 1 of those suppressions (technically 2 lines) applies to all clangs; while the other 1 (also 2 lines) applies to clang-15 and higher. Hence suppressions_clang = the common one; suppressions_clang_17 = the later-version one only; _15 and _16 are symlinks to the latter.