### PR TITLE
This should apply to all consumers of this lib; as opposed to individ…

### DIFF
--- a/src/sanitize/tsan/suppressions_clang.cfg
+++ b/src/sanitize/tsan/suppressions_clang.cfg
@@ -1,0 +1,11 @@
+# In clang-15+ various tests (at least unit_test, transport_test exercise-mode SHM-jemalloc-sub-mode) shows warnings
+# of the type:
+#   SUMMARY: ThreadSanitizer: data race .../src/include/jemalloc/internal/extent_inlines.h:285:17 in extent_...
+# The extent_ function varies, but in all cases it's in a subtree of a `je_arena*()` call; this is inside
+# jemalloc.  I (ygoldfel) have filed a ticket regarding confirming this (as on the topic of SHM-jemalloc I am not
+# the #1 subject matter expert), but IMO: this is very low-level code in the guts of jemalloc, and jemalloc is
+# generally safe w/r/t concurrent calls; so most likely TSAN cannot follow what is going on.  Also similar
+# warnings are observed in unit_test (and a colleague suppressed je_arena* for it similarly).  So:
+# probably it is a false positive; but ticket has been filed to confirm; in the meantime confidence in TSAN
+# coverage (with these suppressions) is high (on my part at least).
+race:je_arena*


### PR DESCRIPTION
…ual tests that use it.  So moved here; will be deleted shortly from there.