### PR TITLE
Internally to SHM-jemalloc use vaddr space less aggressively, avoiding eventual fatal error despite not-high SHM RAM use.

### DIFF
--- a/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.cpp
@@ -338,15 +338,16 @@ void* Shm_pool_collection::create_shm_pool(void* address,
   return pool_address;
 }
 
-bool Shm_pool_collection::optional_remove_shm_pool(void* address,
-                                                   size_t size,
-                                                   bool committed,
-                                                   Arena_id arena_id)
+bool Shm_pool_collection::optional_remove_shm_pool([[maybe_unused]] void* address,
+                                                   [[maybe_unused]] size_t size,
+                                                   [[maybe_unused]] bool committed,
+                                                   [[maybe_unused]] Arena_id arena_id)
 {
   assert(m_started);
   // @todo - MGCOGS-385 - Create decision algorithm
-  // Always remove for now
-  return remove_shm_pool(address, size, committed, arena_id);
+  // Always retain for now
+  return false;
+  // return remove_shm_pool(address, size, committed, arena_id);
 }
 
 bool Shm_pool_collection::remove_shm_pool(void* address,

--- a/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
@@ -26,6 +26,7 @@
 #include "ipc/shm/arena_lend/jemalloc/memory_manager.hpp"
 #include "ipc/shm/arena_lend/jemalloc/detail/jemalloc.hpp"
 #include "ipc/shm/arena_lend/jemalloc/test/test_jemalloc_pages.hpp"
+#include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/test/test_logger.hpp"
 #include <bitset>
 #include <sys/mman.h>
@@ -884,7 +885,11 @@ TEST(Jemalloc_memory_manager_test, Interface)
     // Clean up arenas
     for (const auto& iter : arena_ids)
     {
-      EXPECT_NO_THROW(memory_manager.destroy_arena(iter));
+      using ipc::shm::arena_lend::test::check_empty_collection_in_output;
+      EXPECT_TRUE(check_empty_collection_in_output(ipc::test::collect_output([&memory_manager, &iter]()
+                                                                             {
+                                                                               memory_manager.destroy_arena(iter);
+                                                                             })));
       // Illegal arena indices, which does not crash today, but check if there's change in behavior
       EXPECT_THROW(memory_manager.destroy_arena(iter), std::system_error);
     }

--- a/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
@@ -906,20 +906,10 @@ TEST_F(Jemalloc_shm_pool_collection_test, Interface)
     }
 
     // Destroy arenas
-    EXPECT_TRUE(check_output([&]()
-                             {
-                               collection = nullptr;
-                             },
-                             cout,
-                             form_arena_destruction_output_checks(collection)));
-
-    if (event_listener.get_num_shared_memory_objects() > 0UL)
-    {
-      EXPECT_EQ(event_listener.get_num_shared_memory_objects(), 0UL);
-      ostringstream os;
-      event_listener.print_shared_memory_objects(os);
-      FLOW_LOG_WARNING(os.str());
-    }
+    auto checks = form_arena_destruction_output_checks(collection);
+    auto output = collect_output([&]() { collection = nullptr; });
+    EXPECT_TRUE(check_output(output, checks));
+    EXPECT_TRUE(check_empty_collection_in_output(output));
   }
 
   {

--- a/src/ipc/shm/arena_lend/test/test_event_listener.hpp
+++ b/src/ipc/shm/arena_lend/test/test_event_listener.hpp
@@ -106,14 +106,6 @@ public:
   }; // class Remove_notification
 
   /**
-   * Destructor. Checks that there are no residual memory mappings remaining.
-   */
-  ~Test_event_listener()
-  {
-    EXPECT_TRUE(m_shared_memory_map.empty());
-  }
-
-  /**
    * Stores the notification data for a creation event.
    *
    * @param shm_pool The shared memory pool that was created.


### PR DESCRIPTION
  API notes (ATTN when writing release notes):
  - New APIs:
    - interfaces/concepts `...`, classes `...`
    - functions `...()`
    - function overloads `...(...args...)`
    - ...
  - Breaking changes:
    - removed APIs ...
    - behavior differences ...
    - ...

  Impl notes:
  - (by @echan-dev) Retain optionally requested shared memory pool removals. This is to avoid gaps and the eventual removal of the pool, which eventually may signal to jemalloc to increase the size by double in the next memory pool allocation. -echan)

  Code review notes:

  @echan-dev made this change elsewhere. I have reviewed it. Therefore, forgoing code review in this PR.