### PR TITLE
Flow has gained a unit test suite similar to Flow-IPC and now houses various common test utilities, so they are removed here, and instead we reuse them from their new location in Flow. / In test/demo programs using the new (albeit optional) flow::log::Config::init_component_to_union_idx_mapping() arg in the now-recommended way.

### DIFF
--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/shm_session_test.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/shm_session_test.cpp
@@ -42,6 +42,7 @@
 #include "ipc/shm/stl/stateless_allocator.hpp"
 #include "ipc/test/test_common_util.hpp"
 #include "ipc/test/test_logger.hpp"
+#include <flow/test/test_common_util.hpp>
 
 namespace chrono = std::chrono;
 
@@ -79,9 +80,9 @@ using ipc::shm::arena_lend::Shm_pool;
 using ipc::shm::arena_lend::jemalloc::Ipc_arena;
 using ipc::shm::arena_lend::jemalloc::Memory_manager;
 
-using ipc::test::check_output;
+using flow::test::check_output;
 using ipc::test::Test_logger;
-using ipc::test::to_underlying;
+using flow::test::to_underlying;
 using ipc::session::schema::MqType;
 
 using Mutex = std::mutex;

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server.cpp
@@ -28,6 +28,7 @@
 #include "ipc/shm/arena_lend/jemalloc/jemalloc_pages.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/test/test_common_util.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <boost/filesystem.hpp>
 
 namespace fs = boost::filesystem;
@@ -46,7 +47,7 @@ using namespace ipc::shm::arena_lend::test;
 using ipc::Error_code;
 using ipc::shm::arena_lend::Shm_pool;
 using ipc::util::Process_credentials;
-using ipc::test::check_output;
+using flow::test::check_output;
 using ipc::test::get_process_creds;
 
 namespace ipc::session::shm::arena_lend::jemalloc::test
@@ -171,7 +172,7 @@ Test_shm_session_server::Test_shm_session_server(flow::log::Logger* logger,
   m_performance_expected_clients(performance_expected_clients)
 {
   Error_code ec;
-  if (!ipc::test::create_directory_if_not_exists(S_KERNEL_PERSISTENT_RUN_DIR, ec))
+  if (!flow::test::create_directory_if_not_exists(S_KERNEL_PERSISTENT_RUN_DIR, ec))
   {
     FLOW_LOG_WARNING("Could not create kernel persistent directory [" << S_KERNEL_PERSISTENT_RUN_DIR << "]");
     return;

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server.hpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server.hpp
@@ -30,7 +30,7 @@
 #include "ipc/shm/arena_lend/jemalloc/ipc_arena.hpp"
 #include "ipc/shm/arena_lend/owner_shm_pool_listener_for_repository.hpp"
 #include "ipc/session/session_server.hpp"
-#include "ipc/test/test_file_util.hpp"
+#include <flow/test/test_file_util.hpp>
 #include <boost/filesystem.hpp>
 
 namespace ipc::session::shm::arena_lend::jemalloc::test

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server_executor.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server_executor.cpp
@@ -26,7 +26,7 @@
 #include "ipc/shm/arena_lend/jemalloc/ipc_arena.hpp"
 #include "ipc/shm/stl/stateless_allocator.hpp"
 #include "ipc/test/test_logger.hpp"
-#include "ipc/test/test_common_util.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <future>
 
 namespace chrono = std::chrono;
@@ -176,7 +176,7 @@ Object_creation_callback Test_shm_session_server_executor::many_objects_creator_
   using Timer = flow::perf::Checkpointing_timer;
   using flow::perf::Clock_type;
   using flow::perf::Clock_types_subset;
-  using ipc::test::to_underlying;
+  using flow::test::to_underlying;
 
   return
     [](const shared_ptr<Ipc_arena>& shm_arena,

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server_launcher.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server_launcher.cpp
@@ -26,6 +26,7 @@
 #include "ipc/session/standalone/shm/arena_lend/jemalloc/test/test_shm_session_server.hpp"
 #include "ipc/test/test_common_util.hpp"
 #include <ipc/common.hpp>
+#include <flow/test/test_common_util.hpp>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 #pragma GCC diagnostic ignored "-Wnarrowing"
@@ -35,7 +36,7 @@
 
 using std::ostream;
 using std::string;
-using ipc::test::to_underlying;
+using flow::test::to_underlying;
 
 namespace ipc::session::shm::arena_lend::jemalloc::test
 {

--- a/src/ipc/session/standalone/shm/arena_lend/test/borrower_collection_test.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/test/borrower_collection_test.cpp
@@ -27,7 +27,6 @@
 #include "ipc/shm/arena_lend/test/test_shm_pool_collection.hpp"
 #include "ipc/test/test_logger.hpp"
 
-using namespace ipc::test;
 using std::shared_ptr;
 using std::size_t;
 using std::string;
@@ -64,7 +63,7 @@ TEST(Borrower_collection_test, Interface)
   // The offset of an object that will not be registered\; used for negative testing
   const size_t UNREGISTERED_OBJECT_OFFSET = 40;
 
-  Test_logger logger;
+  ipc::test::Test_logger logger;
   shared_ptr<Borrower_shm_pool_collection> borrower_shm_pool_collection =
     std::make_shared<Borrower_shm_pool_collection>(&logger, Test_shm_pool_collection::S_DEFAULT_COLLECTION_ID);
   Borrower_collection collection(&logger, borrower_shm_pool_collection);

--- a/src/ipc/session/standalone/shm/arena_lend/test/lender_collection_test.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/test/lender_collection_test.cpp
@@ -31,7 +31,8 @@
 #include "ipc/test/test_logger.hpp"
 #include <unordered_set>
 
-using namespace ipc::test;
+using ipc::test::create_fake_shared_object;
+using ipc::test::Test_logger;
 using std::make_shared;
 using std::shared_ptr;
 using std::size_t;

--- a/src/ipc/shm/arena_lend/detail/shm_pool_offset_ptr_data.cpp
+++ b/src/ipc/shm/arena_lend/detail/shm_pool_offset_ptr_data.cpp
@@ -80,10 +80,10 @@ Shm_pool_offset_ptr_data_base::pool_id_t Shm_pool_offset_ptr_data_base::generate
 
     Config std_log_config(Sev::S_WARNING); // Errors only.  (Only errors would appear anyway as of now but still.)
     std_log_config.init_component_to_union_idx_mapping<Flow_log_component>
-      (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>());
+      (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>(), true);
     std_log_config.init_component_names<Flow_log_component>(flow::S_FLOW_LOG_COMPONENT_NAME_MAP, false, "flow-");
     std_log_config.init_component_to_union_idx_mapping<Log_component>
-      (2000, Config::standard_component_payload_enum_sparse_length<Log_component>());
+      (2000, Config::standard_component_payload_enum_sparse_length<Log_component>(), true);
     std_log_config.init_component_names<Log_component>(S_IPC_LOG_COMPONENT_NAME_MAP, false, "ipc-");
 
     Simple_ostream_logger std_logger(&std_log_config); // Go to default (cout, cerr).  Only cerr in practice.

--- a/src/ipc/shm/arena_lend/jemalloc/test/ipc_arena_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/ipc_arena_test.cpp
@@ -29,7 +29,7 @@
 #include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/test/test_logger.hpp"
 
-using namespace ipc::test;
+using ipc::test::Test_logger;
 
 using std::make_shared;
 using std::make_unique;

--- a/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/jemalloc_pages_test.cpp
@@ -27,14 +27,15 @@
 #include "ipc/shm/arena_lend/test/test_shm_pool_collection.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/test/test_logger.hpp"
-#include "ipc/test/test_common_util.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <sys/time.h>
 #include <sys/resource.h>
 
+using ipc::test::Test_logger;
 using std::size_t;
 using std::string;
 
-using namespace ipc::test;
+using namespace flow::test;
 using namespace ipc::shm::arena_lend::test;
 
 namespace ipc::shm::arena_lend::jemalloc::test

--- a/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/memory_manager_test.cpp
@@ -28,6 +28,7 @@
 #include "ipc/shm/arena_lend/jemalloc/test/test_jemalloc_pages.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/test/test_logger.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <bitset>
 #include <sys/mman.h>
 #include <limits.h>
@@ -35,7 +36,7 @@
 using std::size_t;
 using std::set;
 using std::string_view;
-using namespace ipc::test;
+using ipc::test::Test_logger;
 
 namespace ipc::shm::arena_lend::jemalloc::test
 {
@@ -886,10 +887,10 @@ TEST(Jemalloc_memory_manager_test, Interface)
     for (const auto& iter : arena_ids)
     {
       using ipc::shm::arena_lend::test::check_empty_collection_in_output;
-      EXPECT_TRUE(check_empty_collection_in_output(ipc::test::collect_output([&memory_manager, &iter]()
-                                                                             {
-                                                                               memory_manager.destroy_arena(iter);
-                                                                             })));
+      EXPECT_TRUE(check_empty_collection_in_output(flow::test::collect_output([&memory_manager, &iter]()
+                                                                              {
+                                                                                memory_manager.destroy_arena(iter);
+                                                                              })));
       // Illegal arena indices, which does not crash today, but check if there's change in behavior
       EXPECT_THROW(memory_manager.destroy_arena(iter), std::system_error);
     }

--- a/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
@@ -31,14 +31,16 @@
 #include "ipc/shm/arena_lend/test/test_event_listener.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_object.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_pool_collection.hpp"
-#include "ipc/test/test_common_util.hpp"
+#include <flow/test/test_common_util.hpp>
 #include "ipc/test/test_logger.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <iostream>
 #include <sys/mman.h>
 #include <deque>
 #include <optional>
 #include <random>
 
+using ipc::test::Test_logger;
 using std::array;
 using std::cerr;
 using std::cout;
@@ -58,7 +60,7 @@ using std::unique_ptr;
 using std::vector;
 
 using namespace ipc::shm::arena_lend::test;
-using namespace ipc::test;
+using namespace flow::test;
 
 namespace ipc::shm::arena_lend::jemalloc::test
 {

--- a/src/ipc/shm/arena_lend/test/borrower_shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/test/borrower_shm_pool_collection_test.cpp
@@ -31,13 +31,15 @@
 #include "ipc/shm/arena_lend/test/test_shm_pool_collection.hpp"
 #include "ipc/test/test_common_util.hpp"
 #include "ipc/test/test_logger.hpp"
+#include <flow/test/test_common_util.hpp>
 
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
 using std::size_t;
 
-using namespace ipc::test;
+using ipc::test::Test_logger;
+using flow::test::get_test_suite_name;
 
 namespace ipc::shm::arena_lend::test
 {

--- a/src/ipc/shm/arena_lend/test/owner_shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/test/owner_shm_pool_collection_test.cpp
@@ -41,6 +41,7 @@
 #include <unordered_set>
 #include <random>
 
+using ipc::test::Test_logger;
 using std::cerr;
 using std::make_shared;
 using std::make_unique;
@@ -51,7 +52,7 @@ using std::unique_ptr;
 using std::vector;
 using ipc::util::Permissions;
 
-using namespace ipc::test;
+using namespace flow::test;
 
 namespace ipc::shm::arena_lend::test
 {

--- a/src/ipc/shm/arena_lend/test/shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/test/shm_pool_collection_test.cpp
@@ -27,8 +27,8 @@
 #include "ipc/shm/arena_lend/shm_pool.hpp"
 #include "ipc/shm/arena_lend/test/test_borrower.hpp"
 #include "ipc/shm/arena_lend/test/test_shm_pool_collection.hpp"
-#include "ipc/test/test_common_util.hpp"
 #include "ipc/test/test_logger.hpp"
+#include <flow/test/test_common_util.hpp>
 #include <sstream>
 
 using std::make_shared;
@@ -36,7 +36,8 @@ using std::shared_ptr;
 using std::string;
 using std::size_t;
 using std::cout;
-using namespace ipc::test;
+using ipc::test::Test_logger;
+using flow::test::check_output;
 
 namespace ipc::shm::arena_lend::test
 {

--- a/src/ipc/shm/arena_lend/test/test_shm_object.cpp
+++ b/src/ipc/shm/arena_lend/test/test_shm_object.cpp
@@ -26,6 +26,7 @@
 #include "ipc/test/test_logger.hpp"
 #include <sstream>
 #include <boost/filesystem.hpp>
+#include <flow/test/test_common_util.hpp>
 #include <flow/log/log.hpp>
 
 using std::string;
@@ -56,7 +57,7 @@ string generate_shm_object_name(const string& prefix)
 
 Owner_shm_pool_collection::Shm_object_name_generator create_shm_object_name_generator(const string& use_case_id)
 {
-  string actual_use_case_id = (use_case_id.empty() ? ipc::test::get_test_suite_name() : use_case_id);
+  string actual_use_case_id = (use_case_id.empty() ? flow::test::get_test_suite_name() : use_case_id);
   return [actual_use_case_id = std::move(actual_use_case_id)](auto&&)
          {
            return generate_shm_object_name(S_SHM_OBJECT_NAME_PREFIX + actual_use_case_id);
@@ -106,7 +107,7 @@ bool remove_shm_objects_filesystem(const string& prefix)
 bool remove_test_shm_objects_filesystem()
 {
   string prefix = S_SHM_OBJECT_NAME_PREFIX;
-  prefix += ipc::test::get_test_suite_name();
+  prefix += flow::test::get_test_suite_name();
   prefix += "_";
 
   return remove_shm_objects_filesystem(prefix);

--- a/src/ipc/shm/arena_lend/test/test_shm_object.hpp
+++ b/src/ipc/shm/arena_lend/test/test_shm_object.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <iostream>
 #include "ipc/shm/arena_lend/owner_shm_pool_collection.hpp"
-#include "ipc/test/test_common_util.hpp"
+#include <flow/test/test_common_util.hpp>
 
 namespace ipc::shm::arena_lend::test
 {
@@ -107,7 +107,7 @@ template <typename Owner_shm_pool_collection_pointer_type>
 bool ensure_empty_collection_at_destruction(Owner_shm_pool_collection_pointer_type& shm_pool_collection,
                                             std::ostream& os = std::cout)
 {
-  std::string output = ipc::test::collect_output([&shm_pool_collection]() { shm_pool_collection = nullptr; }, os);
+  std::string output = flow::test::collect_output([&shm_pool_collection]() { shm_pool_collection = nullptr; }, os);
   return check_empty_collection_in_output(output);
 }
 

--- a/test/basic/link_test/common.cpp
+++ b/test/basic/link_test/common.cpp
@@ -94,9 +94,9 @@ void setup_logging(std::optional<flow::log::Simple_ostream_logger>* std_logger,
   // Console logger setup.
   static Config std_log_config;
   std_log_config.init_component_to_union_idx_mapping<Flow_log_component>
-    (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>());
+    (1000, Config::standard_component_payload_enum_sparse_length<Flow_log_component>(), true);
   std_log_config.init_component_to_union_idx_mapping<ipc::Log_component>
-    (2000, Config::standard_component_payload_enum_sparse_length<ipc::Log_component>());
+    (2000, Config::standard_component_payload_enum_sparse_length<ipc::Log_component>(), true);
   std_log_config.init_component_names<Flow_log_component>(flow::S_FLOW_LOG_COMPONENT_NAME_MAP, false, "flow-");
   std_log_config.init_component_names<ipc::Log_component>(ipc::S_IPC_LOG_COMPONENT_NAME_MAP, false, "ipc-");
   std_logger->emplace(&std_log_config);


### PR DESCRIPTION
necessary part of fix to Flow-IPC/flow#94

  To code reviewer:

  Forgoing code review:
  - Am owner.
  - Source code changes are test-only and comprise only moving certain items into a common location in Flow + version bump for GTest. That, also, was reviewed in a Flow PR. Plus there is a minor test change due to the new Flow feature; it is insignificant and self-explanatory.
