### PR TITLE
Removed and replaced SHM-jemalloc `Arena::construct<T>(bool use_cache, ...)` overload API due to potential overload ambiguity for some `T`s.  (Impl: It has become private `construct_impl()`; `construct(args...)` continues to call `construct_impl(false, ...)`, as it was calling the deleted overload before.  New API `construct_thread_cached()` calls `construct_impl(true, ...)`.) / Ipc_arena public super-class Shm_pool_collection also has a construct() with potentially ambiguous signature; renamed to construct_maybe_thread_cached(). / Comment and/or doc changes.

### DIFF
--- a/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.hpp
+++ b/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.hpp
@@ -139,7 +139,7 @@ public:
    *
    * @return A shared pointer to an object created in shared memory.
    *
-   * @see construct(Arena_id, Args&&...)
+   * @see construct_in_arena(Arena_id, Args&&...)
    */
   template <typename T, typename... Args>
   std::shared_ptr<T> construct(bool use_cache, Args&&... args)

--- a/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.hpp
+++ b/src/ipc/shm/arena_lend/jemalloc/shm_pool_collection.hpp
@@ -142,7 +142,7 @@ public:
    * @see construct_in_arena(Arena_id, Args&&...)
    */
   template <typename T, typename... Args>
-  std::shared_ptr<T> construct(bool use_cache, Args&&... args)
+  std::shared_ptr<T> construct_maybe_thread_cached(bool use_cache, Args&&... args)
   {
     assert(m_started);
 

--- a/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/test/shm_pool_collection_test.cpp
@@ -181,15 +181,15 @@ public:
   }; // class Thread_cache_holder
 
   /**
-   * Creates an instance of this class along with its arenas. We require this, because the construct() interface
-   * requires the use of shared pointers.
+   * Creates an instance of this class along with its arenas. We require this, because the
+   * construct_maybe_thread_cached() interface requires the use of shared pointers.
    *
    * @param logger Used for logging purposes.
    * @param memory_manager The memory allocator.
    *
    * @return Upon success, a shared pointer to an instance of this class; otherwise, an empty shared pointer.
    *
-   * @see Shm_pool_collection::construct()
+   * @see Shm_pool_collection::construct_maybe_thread_cached()
    */
   static shared_ptr<Test_shm_pool_collection> create(
     flow::log::Logger* logger,
@@ -669,7 +669,7 @@ TEST_F(Jemalloc_shm_pool_collection_DeathTest, Interface)
     // Not started yet
     EXPECT_DEATH(collection->allocate(100), "m_started");
     EXPECT_DEATH(collection->allocate(100, 0UL), "m_started");
-    EXPECT_DEATH(collection->construct<int>(false, 100), "m_started");
+    EXPECT_DEATH(collection->construct_maybe_thread_cached<int>(false, 100), "m_started");
     EXPECT_DEATH(collection->construct_in_arena<int>(0UL, false, 100), "m_started");
     EXPECT_DEATH(collection->construct_in_arena<int>(0UL, true, 100), "m_started");
     EXPECT_DEATH(collection->deallocate(reinterpret_cast<void*>(0x1)), "m_started");
@@ -855,9 +855,9 @@ TEST_F(Jemalloc_shm_pool_collection_test, Interface)
                                  {
                                    if (use_default)
                                    {
-                                     foo = collection->construct<Foo>(use_cache,
-                                                                      constructor_counter,
-                                                                      destructor_counter);
+                                     foo = collection->construct_maybe_thread_cached<Foo>(use_cache,
+                                                                                          constructor_counter,
+                                                                                          destructor_counter);
                                    }
                                    else
                                    {
@@ -940,7 +940,7 @@ TEST_F(Jemalloc_shm_pool_collection_test, Interface)
         if (objects.size() == 0)
         {
           // Construct using first arena
-          cur_object = collection->construct<int>(use_cache, ARBITRARY_VALUE);
+          cur_object = collection->construct_maybe_thread_cached<int>(use_cache, ARBITRARY_VALUE);
         }
         else
         {


### PR DESCRIPTION
necessary part of fix of Flow-IPC/ipc_shm_arena_lend#56

  API notes (ATTN when writing release notes):
  - New APIs:
    - `ipc::shm::arena_lend::jemalloc::Ipc_arena::construct_thread_cached()`: replaces removed `construct(true, ...)`.
    - `ipc::shm::arena_lend::jemalloc::Shm_pool_collection::construct_maybe_thread_cached()`: replaces removed `construct()`.
  - Breaking changes:
    - Removed `ipc::shm::arena_lend::jemalloc::Ipc_arena::construct(bool use_cache)`.
      - For `use_cache = true`, call `construct_thread_cached()` (new).
      - For `use_cache = false`, call `construct(Ctor_args&&... args)`.
    - Renamed `ipc::shm::arena_lend::jemalloc::Shm_pool_collection::construct()` to `maybe_thread_caching()`.

  To code reviewer:

  Should be self-explanatory given the above notes.