### PR TITLE
`ipc::session::shm::arena_lend::jemalloc::Shm_session` internal bug fix to avoid assertion-trip and/or instability under intense concurrent allocation load.

### DIFF
--- a/src/ipc/session/detail/shm/arena_lend/jemalloc/client_session_impl.hpp
+++ b/src/ipc/session/detail/shm/arena_lend/jemalloc/client_session_impl.hpp
@@ -446,7 +446,6 @@ bool CLASS_JEM_CLI_SESSION_IMPL::async_connect
          * on this side there's nothing further to do either.  So just report the result of init_shm(). */
         err_code = Base::init_shm(std::move(local_hndl_or_null),
                                   Shared_name::ct(to_string(util::Process_credentials::own_process_id())));
-
         if (!err_code)
         {
           /* I lied (Arnie voice from Commando).  We also need to do this for each arena (we have just the one).

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
@@ -387,7 +387,7 @@ bool Shm_session::send_message(const Shm_channel::Msg_out& message,
   bool result;
 
   {
-    Lock lock(m_shm_channel_mutex);
+    //XXX Lock lock(m_shm_channel_mutex);
     result = m_shm_channel.send(message, original_message, &ec);
   }
 
@@ -415,7 +415,7 @@ bool Shm_session::send_sync_request(const Shm_channel::Msg_out& message, const s
   Shm_channel::Msg_in_ptr response;
 
   {
-    Lock lock(m_shm_channel_mutex);
+    //XXX Lock lock(m_shm_channel_mutex);
     response = m_shm_channel.sync_request(message, nullptr, m_shm_channel_request_timeout, &ec);
   }
 

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
@@ -450,9 +450,15 @@ private:
   /// Maps an arena to an arena shared memory pool listener; this is used for receiving changes in the SHM pools.
   std::unordered_map<std::shared_ptr<ipc::shm::arena_lend::jemalloc::Ipc_arena>,
                      std::unique_ptr<Shm_pool_listener_impl>> m_shm_pool_listener_map;
-  /// Mutex to protect access to mutable operations of #m_shm_channel
-  Mutex m_shm_channel_mutex;
-  /// The channel used for transmitting shared memory pool messages.
+  /// Mutex to prevent `m_shm_channel.sync_request()` concurrently with itself
+  Mutex m_shm_channel_sync_request_mutex;
+  /**
+   * The channel used for transmitting shared memory pool messages.
+   * Note that by transport::struc::Channel contract it *is safe* to execute `m_shm_channel.X()`
+   * and `m_shm_channel.Y()` concurrently for all `X` and `Y` (whether they're the same method or not),
+   * except when `X` and `Y` are both `sync_request`. Hence #m_shm_channel_sync_request_mutex protects
+   * against the latter.
+   */
   Shm_channel& m_shm_channel;
   /// The other end's process id cached from #m_shm_channel used for registering borrowed items.
   const util::process_id_t m_remote_process_id;

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
@@ -450,6 +450,8 @@ private:
   /// Maps an arena to an arena shared memory pool listener; this is used for receiving changes in the SHM pools.
   std::unordered_map<std::shared_ptr<ipc::shm::arena_lend::jemalloc::Ipc_arena>,
                      std::unique_ptr<Shm_pool_listener_impl>> m_shm_pool_listener_map;
+  /// Mutex to protect access to mutable operations of #m_shm_channel
+  Mutex m_shm_channel_mutex;
   /// The channel used for transmitting shared memory pool messages.
   Shm_channel& m_shm_channel;
   /// The other end's process id cached from #m_shm_channel used for registering borrowed items.


### PR DESCRIPTION
part of fix to Flow-IPC/ipc_shm_arena_lend#61

CC @echan-dev 

## Impl notes
* Per nearby `ipc_transport_structured` commit, struc::Channel is thread-safe for all concurrent method calls, except that concurrent `.sync_request()`s on the same `*this` are not allowed.  Hence mutex-protecting around that call only, in Shm_session.

## To code reviewer
Forgoing code review, because already reviewed elsewhere.
