### PR TITLE
`ipc::session::shm::arena_lend::jemalloc::Shm_session` internal improvement (no effect on functionality).

### DIFF
--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
@@ -405,19 +405,7 @@ bool Shm_session::send_message(const Shm_channel::Msg_out& message,
 bool Shm_session::send_sync_request(const Shm_channel::Msg_out& message, const string& operation)
 {
   flow::Error_code ec;
-  Shm_channel::Msg_in_ptr response;
-
-  {
-    /* Reminder: m_shm_channel.X() concurrent calls are OK generally, except that concurrent `.sync_request()`s
-     * are not allowed. So we lock this here (and only here). Perf/responsiveness note: Our expectation is that
-     * this is non-blocking (even though .sync_request() *generally* may block): since the session is up/coming up,
-     * the opposing side shall respond ASAP. (The timeout is an optional safety measure.) This non-blockingness can be
-     * important, as this code in the case of a lend-pool msg is synchronously inside a user SHM-allocation path
-     * (but only when a new pool must be created as part of the SHM-allocation). */
-    Lock lock(m_shm_channel_sync_request_mutex);
-
-    response = m_shm_channel.sync_request(message, nullptr, m_shm_channel_request_timeout, &ec);
-  }
+  auto response = m_shm_channel.sync_request(message, nullptr, m_shm_channel_request_timeout, &ec);
 
   if (!response && !ec)
   {

--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.hpp
@@ -450,14 +450,10 @@ private:
   /// Maps an arena to an arena shared memory pool listener; this is used for receiving changes in the SHM pools.
   std::unordered_map<std::shared_ptr<ipc::shm::arena_lend::jemalloc::Ipc_arena>,
                      std::unique_ptr<Shm_pool_listener_impl>> m_shm_pool_listener_map;
-  /// Mutex to prevent `m_shm_channel.sync_request()` concurrently with itself
-  Mutex m_shm_channel_sync_request_mutex;
   /**
    * The channel used for transmitting shared memory pool messages.
    * Note that by transport::struc::Channel contract it *is safe* to execute `m_shm_channel.X()`
-   * and `m_shm_channel.Y()` concurrently for all `X` and `Y` (whether they're the same method or not),
-   * except when `X` and `Y` are both `sync_request`. Hence #m_shm_channel_sync_request_mutex protects
-   * against the latter.
+   * and `m_shm_channel.Y()` concurrently for all `X` and `Y` (whether they're the same method or not).
    */
   Shm_channel& m_shm_channel;
   /// The other end's process id cached from #m_shm_channel used for registering borrowed items.


### PR DESCRIPTION
part of fix to Flow-IPC/ipc_shm_arena_lend#61

## Impl notes
* No need to explicitly synchronize the internal-channel `.sync_request()` calls, as the `Channel` API now guarantees this itself.

## To code reviewer
Forgoing code review, because already reviewed elsewhere by @echan-dev.
