### PR TITLE
Renaming various internal-use threads to be shorter and ideally with the more useful information up-front, in case the Linux cut-off limit truncates. / Using flow::async::reset_this_thread_pinning() at the start of various worker threads which should remain as independent and as responsive as possible.

### DIFF
--- a/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
+++ b/src/ipc/session/standalone/shm/arena_lend/jemalloc/shm_session.cpp
@@ -71,6 +71,8 @@ Shm_session::Shm_session(flow::log::Logger* logger,
   m_serial_task_loop(logger, ("JSSS_" + to_string(m_remote_process_id))),
   m_parallel_task_loop(logger, ("JSSP_" + to_string(m_remote_process_id)), 0)
 {
+  using flow::async::reset_this_thread_pinning;
+
   FLOW_LOG_TRACE("Constructing [" << this << "]");
 
   if (!register_expected_messages())
@@ -79,8 +81,9 @@ Shm_session::Shm_session(flow::log::Logger* logger,
   }
 
   m_borrower_repository.register_owner(m_remote_process_id);
-  m_serial_task_loop.start();
-  m_parallel_task_loop.start();
+  m_serial_task_loop.start(reset_this_thread_pinning);
+  m_parallel_task_loop.start(reset_this_thread_pinning);
+  // Don't inherit any strange core-affinity!  ^-- Workers (could be lots of them!) must float free.
 }
 
 Shm_session::~Shm_session()


### PR DESCRIPTION
related to https://github.com/Flow-IPC/flow/issues/108, https://github.com/Flow-IPC/flow/issues/71, https://github.com/Flow-IPC/ipc/issues/85

## To code reviewer
Forgoing code review, because already reviewed elsewhere (@code-walkers).