### PR TITLE
(SHM-jemalloc) Removed an INFO-severity logged message that is logged from `ipc::shm::arena_lend::jemalloc::Ipc_arena::get_collection_id()`, a public API but more likely invoked internally from `Shm_session::lend_object()` which can be oft-used directly and/or for each capnp-encoded message sent through a SHM-jemalloc-backed `ipc::transport::struc::Channel`. / Use move-semantics in a few places internally to avoid unnecessary `shared_ptr` ref-count arithmetic. / Effectively remove a few redundant internal `assert()`s. / Comment and/or doc changes.

### DIFF
--- a/src/ipc/shm/arena_lend/jemalloc/ipc_arena.cpp
+++ b/src/ipc/shm/arena_lend/jemalloc/ipc_arena.cpp
@@ -240,14 +240,14 @@ void Ipc_arena::Event_listener_impl::notify_removed_shm_pool(const shared_ptr<Sh
 }
 
 Ipc_arena::Ipc_object_deleter_no_cache::Ipc_object_deleter_no_cache(
-  const shared_ptr<Shm_pool_collection>& pool_collection, Arena_id arena_id) :
-  Object_deleter_no_cache(pool_collection, arena_id)
+  shared_ptr<Shm_pool_collection>&& pool_collection, Arena_id arena_id) :
+  Object_deleter_no_cache(std::move(pool_collection), arena_id)
 {
 }
 
 Ipc_arena::Ipc_object_deleter_cache::Ipc_object_deleter_cache(
-  const shared_ptr<Thread_cache>& thread_cache) :
-  Object_deleter_cache(thread_cache)
+  shared_ptr<Thread_cache>&& thread_cache) :
+  Object_deleter_cache(std::move(thread_cache))
 {
 }
 

--- a/src/ipc/shm/arena_lend/owner_shm_pool_collection.hpp
+++ b/src/ipc/shm/arena_lend/owner_shm_pool_collection.hpp
@@ -266,9 +266,9 @@ protected:
   inline std::string generate_shm_object_name(pool_id_t shm_pool_id) const;
 
   /**
-   * Performs an allocation backed by shared memory, uses the allocation to construct an object and returns a shared
+   * Construct an object at a pre-allocated location in shared memory and returns a shared
    * pointer to this object. When the shared pointer has no more references, it will be destructed by this pool
-   * collection instance. The start() method must be executed prior to any calls to this.
+   * collection instance via the given deleter. The start() method must be executed prior to any calls to this.
    *
    * @tparam T The object type to be created.
    * @tparam Deleter A copy-constructible class containing operator() that performs destruction of the memory.


### PR DESCRIPTION
relates to Flow-IPC/ipc#143

## To code reviewer
Forgoing code review, because reviewed elsewhere by @wkorbe.